### PR TITLE
remove confusing build script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
 - main
 
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-24.04
 
 steps:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,11 @@ trigger:
 - main
 
 pool:
-  vmImage: ubuntu-24.04
+  # ERROR    InvalidDistribution: Invalid distribution metadata: unrecognized or    
+  #          malformed field 'license-file'  
+  # vmImage: ubuntu-24.04
+
+  vmImage: ubuntu-22.04 # FIXME: deprecate setup.py
 
 steps:
 

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-docker pull kungfu.azurecr.io/mw-megatron-lm-23.06:latest
-
-./Dockerfile
-
-docker push kungfu.azurecr.io/mw-megatron-lm-23.06-tenplex:latest


### PR DESCRIPTION
This script uses images that are no longer exist, which confuses users.

The only available images are 

```
kungfu.azurecr.io/mw-megatron-lm-23.06-update:latest (which is v0.0.3, used for AE)
kungfu.azurecr.io/mw-megatron-lm-23.06-update:v0.0.3
kungfu.azurecr.io/mw-megatron-lm-23.06-update:v0.0.2
kungfu.azurecr.io/mw-megatron-lm-23.06-update:v0.0.1
```